### PR TITLE
Automatically add doctype if missing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -223,8 +223,12 @@ async function prerender (parentCompilation, request, options, inject, loader) {
   }
 
   // dom.serialize() doesn't properly serialize HTML appended to document.body.
-  return dom.serialize();
   // return `<!DOCTYPE ${window.document.doctype.name}>${window.document.documentElement.outerHTML}`;
+  let serialized = dom.serialize();
+  if (!/^<!DOCTYPE /mi.test(serialized)) {
+    serialized = `<!DOCTYPE html>${serialized}`;
+  }
+  return serialized;
 
   // // Returning or resolving to `null` / `undefined` defaults to serializing the whole document.
   // // Note: this pypasses `inject` because the document is already derived from the template.


### PR DESCRIPTION
I had been under the impression jsdom's `serialize()` did this, but it doesn't. Now we do.