### PR TITLE
Add `documentUrl` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ const prerenderedHtml = require('!prerender-loader?string!./app.js');
 
 All options are ... optional.
 
-| Option        | Type    | Default       | Description                                                            |
-| ------------- | ------- | ------------- | ---------------------------------------------------------------------- |
-| `string`      | boolean | false         | Output a JS module exporting an HTML String instead of the HTML itself |
-| `disabled`    | boolean | false         | Bypass the loader entirely (but still respect `options.string`)        |
-| `documentUrl` | string  | 'about:blank' | Change the jsdom's URL (affects `window.location`, `document.URL`...)  |
-| `params`      | object  | null          | Options to pass to your prerender function                             |
+| Option        | Type    | Default            | Description                                                            |
+| ------------- | ------- | ------------------ | ---------------------------------------------------------------------- |
+| `string`      | boolean | false              | Output a JS module exporting an HTML String instead of the HTML itself |
+| `disabled`    | boolean | false              | Bypass the loader entirely (but still respect `options.string`)        |
+| `documentUrl` | string  | 'http://localhost' | Change the jsdom's URL (affects `window.location`, `document.URL`...)  |
+| `params`      | object  | null               | Options to pass to your prerender function                             |
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Painless universal prerendering for Webpack. Works great with
 - [How does it work?](#how-does-it-work)
 - [Installation](#installation)
 - [Usage](#usage)
-	- [DOM Prerendering](#dom-prerendering)
-	- [String Prerendering](#string-prerendering)
-	- [Injecting content into the HTML](#injecting-content-into-the-html)
-	- [Prerendering JavaScript Files](#prerendering-javascript-files)
+  - [DOM Prerendering](#dom-prerendering)
+  - [String Prerendering](#string-prerendering)
+  - [Injecting content into the HTML](#injecting-content-into-the-html)
+  - [Prerendering JavaScript Files](#prerendering-javascript-files)
 - [Options](#options)
 - [License](#license)
 
@@ -250,11 +250,12 @@ const prerenderedHtml = require('!prerender-loader?string!./app.js');
 
 All options are ... optional.
 
-| Option     | Type    | Default | Description |
-|------------|---------|---------|-------------|
-| `string`   | boolean | false   | Output a JS module exporting an HTML String instead of the HTML itself
-| `disabled` | boolean | false   | Bypass the loader entirely (but still respect `options.string`)
-| `params`   | object  | null    | Options to pass to your prerender function
+| Option        | Type    | Default       | Description                                                            |
+| ------------- | ------- | ------------- | ---------------------------------------------------------------------- |
+| `string`      | boolean | false         | Output a JS module exporting an HTML String instead of the HTML itself |
+| `disabled`    | boolean | false         | Bypass the loader entirely (but still respect `options.string`)        |
+| `documentUrl` | string  | 'about:blank' | Change the jsdom's URL (affects `window.location`, `document.URL`...)  |
+| `params`      | object  | null          | Options to pass to your prerender function                             |
 
 
 ---

--- a/src/index.js
+++ b/src/index.js
@@ -156,6 +156,10 @@ async function prerender (parentCompilation, request, options, inject, loader) {
       // suppress console-proxied eval() errors, but keep console proxying
       virtualConsole: new jsdom.VirtualConsole({ omitJSDOMErrors: false }).sendTo(console),
 
+      // `url` sets the value returned by `window.location`, `document.URL`...
+      // Useful for routers that depend on the current URL (such as react-router or reach-router)
+      url: options.documentUrl,
+
       // don't track source locations for performance reasons
       includeNodeLocations: false,
 
@@ -187,12 +191,6 @@ async function prerender (parentCompilation, request, options, inject, loader) {
       window.eval(`(function(exports, module, require){\n${asset.source()}\n})`)(mod.exports, mod, window.require);
       return mod.exports;
     };
-
-    // Let the caller reconfigure the JSDOM instance
-    // Useful for chaning the url, window...
-    if (options.reconfigureJsDom) {
-      options.reconfigureJsDom(dom);
-    }
 
     // Invoke the SSR bundle within the JSDOM document and grab the exported/returned result
     result = window.eval(output + '\nPRERENDER_RESULT');

--- a/src/index.js
+++ b/src/index.js
@@ -188,6 +188,12 @@ async function prerender (parentCompilation, request, options, inject, loader) {
       return mod.exports;
     };
 
+    // Let the caller reconfigure the JSDOM instance
+    // Useful for chaning the url, window...
+    if (options.reconfigureJsDom) {
+      options.reconfigureJsDom(dom);
+    }
+
     // Invoke the SSR bundle within the JSDOM document and grab the exported/returned result
     result = window.eval(output + '\nPRERENDER_RESULT');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ async function prerender (parentCompilation, request, options, inject, loader) {
 
       // `url` sets the value returned by `window.location`, `document.URL`...
       // Useful for routers that depend on the current URL (such as react-router or reach-router)
-      url: options.documentUrl,
+      url: options.documentUrl || 'http://localhost',
 
       // don't track source locations for performance reasons
       includeNodeLocations: false,

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -46,3 +46,15 @@ exports[`webpack compilation smoke test (no prerendering) should compile 1`] = `
 </html>
 "
 `;
+
+exports[`webpack compilation smoke test (no prerendering) should propagate child compiler errors 1`] = `
+"<!DOCTYPE html>
+<html>
+<head>
+<title>Basic Demo</title>
+</head>
+<body>
+<script type=\\"text/javascript\\" src=\\"bundle.js\\"></script></body>
+</html>
+"
+`;

--- a/test/fixtures/document-url/index.html
+++ b/test/fixtures/document-url/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>document with different window.location</title>
+</head>
+<body>
+</body>
+</html>

--- a/test/fixtures/document-url/index.js
+++ b/test/fixtures/document-url/index.js
@@ -1,0 +1,1 @@
+export default () => `<div>${window.location}</div>`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -132,4 +132,15 @@ describe('prerender-loader!x.html', () => {
       expect(html).toMatchSnapshot();
     });
   });
+
+  const DOCUMENT_URL = 'http://localhost/page';
+
+  describe(`?documentUrl=${DOCUMENT_URL}`, () => {
+    it('should set the value returned by window.location', async () => {
+      const { document } = await compileToHtml('document-url', configure({ string: true, documentUrl: DOCUMENT_URL }));
+
+      // verify that our DOM-generated content has been prerendered into the static HTML:
+      expect(document.body.firstElementChild).toHaveProperty('outerHTML', `<div>${DOCUMENT_URL}</div>`);
+    });
+  });
 });


### PR DESCRIPTION
Some libraries such as `react-router` or `reach-router` depend on the current window URL (returned by `window.location`, `location.URL`...) to determine which route to render.

This PR adds a `documentUrl` option which is passed to the JSDOM `url` option which has the following behavior according to their [docs](https://github.com/jsdom/jsdom#customizing-jsdom):

`url` sets the value returned by window.location, document.URL, and document.documentURI, and affects things like resolution of relative URLs within the document and the same-origin restrictions and referrer used while fetching subresources. It defaults to "about:blank".

The default value is `undefined` which will tell JSDOM to use the default `about:blank` which you cannot change inside the JSDOM instance.

@developit 