### PR TITLE
Fix for multiple chunks emitting to ssr-bundle.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -71,7 +71,9 @@ export default function PrerenderLoader (content) {
     const matches = content.match(PRERENDER_REG);
     if (matches) {
       inject = true;
-      options.entry = matches[1];
+      if (!options.entry) {
+        options.entry = matches[1];
+      }
     }
     options.templateContent = content;
   }


### PR DESCRIPTION
Prerendering multiple entries in conjunction with the `{{prerender}}` injection point results in the following error:

> Error: Conflict: Multiple chunks emit assets to the same filename ssr-bundle.js

even when an entry is specified in the loader query string for HtmlWebpackPlugin template.

```javascript
const plugin = new HtmlWebpackPlugin({
  // ...
  template: `!!prerender-loader?string&entry=${entryFile}!./src/template.html`
});
```

This appears to be caused by this block clobbering the original entry and changing it to `undefined`.

```javascript
if (matches) {
  inject = true;
  options.entry = matches[1]; // <-- matches[1] is `undefined`
}
```

I'm not sure what the original intention here is, but only reassigning the entry if it's not already set *probably* fixes the issue. I can't say for sure because I can't build due to https://github.com/developit/microbundle/issues/74. Making this change directly to `dist/prerender-loader.js` worked for me.

Fixes https://github.com/GoogleChromeLabs/prerender-loader/issues/29#issuecomment-489229652