### PR TITLE
Allow defining custom env variables for the prerender build

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ All options are ... optional.
 | `disabled`    | boolean | false              | Bypass the loader entirely (but still respect `options.string`)        |
 | `documentUrl` | string  | 'http://localhost' | Change the jsdom's URL (affects `window.location`, `document.URL`...)  |
 | `params`      | object  | null               | Options to pass to your prerender function                             |
+| `env`         | object  | {}                 | Environment variables to define when building JS for prerendering      |
 
 
 ---

--- a/src/index.js
+++ b/src/index.js
@@ -109,9 +109,10 @@ async function prerender (parentCompilation, request, options, inject, loader) {
   compiler.context = parentCompiler.context;
   compiler.outputFileSystem = new MemoryFs();
 
-  // Define PRERENDER to be true within the SSR bundle
+  // Define PRERENDER to be true within the SSR bundle, plus any other custom SSR env vars
   new DefinePlugin({
-    PRERENDER: 'true'
+    PRERENDER: 'true',
+    ...(options.env || {})
   }).apply(compiler);
 
   // ... then define PRERENDER to be false within the client bundle


### PR DESCRIPTION
It's useful to be able to customize the prerender build with custom environment variables. There's two main reasons for this:

* Accepting params can be a bit fiddly (as seen in a few issues here, it seems to require duplicating some entry code to support this + hot reloading easily) and params end up either needing to be made into global vars or drilled down through many layers to places that need them
* In some cases, the code that must be reconfigured runs before your params entrypoint is called, as it's an imported dependency, so params aren't usable.

In my case it's the latter: I'm using styled-components, which doesn't work with server rendering unless their 'Speedy' mode (which manages the CSSOM directly without serializing anything to the DOM) is disabled. Their logic that handles this is here: https://github.com/styled-components/styled-components/blob/25d5a87c6bb5d22b1157c2355bd971e434ec2093/packages/styled-components/src/constants.ts#L15-L31. It checks when initially imported for various environment variables that can be used to disable this, and that code runs before my entrypoint. This makes it very difficult to disable for SSR but enable for production with the current setup!

With this PR, styled components prerenders correctly _and_ retains speedy mode in production builds given this webpack rule:

```js
{
  test: INDEX_HTML,
  use: [{
    loader: 'prerender-loader',
    options: {
      string: true,
      env: {
        SC_DISABLE_SPEEDY: 'true'
      }
    }
  }]
}
```