### PR TITLE
Patch missing TextEncoder/TextDecoder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -187,6 +187,10 @@ async function prerender (parentCompilation, request, options, inject, loader) {
     window.requestAnimationFrame = () => ++counter;
     window.cancelAnimationFrame = () => { };
 
+    // Patch window.TextEncoder/window.TextDecoder (which are now standard in modern browsers) with node implementations
+    window.TextEncoder = require('util').TextEncoder
+    window.TextDecoder = require('util').TextDecoder
+
     // Never prerender Custom Elements: by skipping registration, we get only the Light DOM which is desirable.
     window.customElements = {
       define () {},


### PR DESCRIPTION
window.TextEncoder and window.TextDecoder are standard browser features not supported by JSDOM but which React 18 [now requires](https://github.com/facebook/react/blob/e09518e5bbb78447d6c86481cf0dcafb4b09c734/packages/react-server/src/ReactServerStreamConfigBrowser.js#L107). This PR patches those with the [node implementation](https://nodejs.org/api/util.html#class-utiltextencoder)

Cheers!